### PR TITLE
Fix/only allow one subrow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ third-party/*
 # misc
 .DS_Store
 .sisyphus
+.playwright-mcp
 
 # credentials
 gha-creds-*.json

--- a/backend/Taskfile.sh
+++ b/backend/Taskfile.sh
@@ -70,8 +70,8 @@ docker-run() {
 
 docker-build-and-run() {
   local env_file=${1:-".env"}
-  docker build .
-  docker-run $(docker images --format "{{.ID}}" | head -n 1) 8080 $env_file
+  docker build --platform linux/arm64/v8 .
+  docker-run swim-gen-backend:latest 8080 $env_file
 }
 
 scrape() {
@@ -87,10 +87,10 @@ scrape() {
 }
 
 # Check if the provided argument matches any of the functions
-if [ -n "$1" ] && ! declare -f "$1" > /dev/null; then
+if [ -n "$1" ] && ! declare -f "$1" >/dev/null; then
   echo "Error: Unknown task '$1'"
   echo
-  help  # Show help if the task is not recognized
+  help # Show help if the task is not recognized
   exit 1
 fi
 

--- a/backend/Taskfile.sh
+++ b/backend/Taskfile.sh
@@ -70,7 +70,7 @@ docker-run() {
 
 docker-build-and-run() {
   local env_file=${1:-".env"}
-  docker build --platform linux/arm64/v8 .
+  docker build --platform linux/arm64/v8 -t swim-gen-backend:latest .
   docker-run swim-gen-backend:latest 8080 $env_file
 }
 

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -91,7 +91,7 @@ func setField(field reflect.Value, val string) error {
 // set populates the struct fields with values from environment variables or default values.
 // It uses the struct field tags to determine which environment variable to use.
 func set(ptr any, envTag string, defaultTag string, overwrite bool) error {
-	if reflect.TypeOf(ptr).Kind() != reflect.Ptr {
+	if reflect.TypeOf(ptr).Kind() != reflect.Pointer {
 		return fmt.Errorf("not a pointer")
 	}
 

--- a/backend/internal/models/json.go
+++ b/backend/internal/models/json.go
@@ -53,7 +53,7 @@ func StructToMap(item any) map[string]any {
 	out := make(map[string]any)
 
 	v := reflect.ValueOf(item)
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		v = v.Elem()
 	}
 

--- a/backend/internal/models/plan.go
+++ b/backend/internal/models/plan.go
@@ -411,8 +411,8 @@ func (t *Table) Validate() error {
 }
 
 func (t *Table) validateRowDepth(depth int) error {
-	if depth > 4 {
-		return fmt.Errorf("maximum nesting depth (4) exceeded")
+	if depth > 1 {
+		return fmt.Errorf("maximum nesting depth (1) exceeded")
 	}
 
 	for i, row := range *t {

--- a/backend/internal/models/plan_test.go
+++ b/backend/internal/models/plan_test.go
@@ -258,7 +258,7 @@ func TestValidate_MaxDepth(t *testing.T) {
 		},
 	}
 	err := table.Validate()
-	assert.Error(t, err, "Table exceeding max depth (5) should fail validation")
+	assert.Error(t, err, "Table exceeding max depth (2) should fail validation")
 }
 
 func TestValidate_ValidMaxDepth(t *testing.T) {
@@ -268,33 +268,12 @@ func TestValidate_ValidMaxDepth(t *testing.T) {
 			Multiplier: "x",
 			Distance:   0,
 			SubRows: []models.Row{
-				{
-					Amount:     2,
-					Multiplier: "x",
-					Distance:   0,
-					SubRows: []models.Row{
-						{
-							Amount:     2,
-							Multiplier: "x",
-							Distance:   0,
-							SubRows: []models.Row{
-								{
-									Amount:     2,
-									Multiplier: "x",
-									Distance:   0,
-									SubRows: []models.Row{
-										{Amount: 1, Distance: 100, Content: "Test", Intensity: "GA1"},
-									},
-								},
-							},
-						},
-					},
-				},
+				{Amount: 1, Distance: 100, Content: "Test", Intensity: "GA1"},
 			},
 		},
 	}
 	err := table.Validate()
-	assert.NoError(t, err, "Valid table at max depth (4) should pass validation")
+	assert.NoError(t, err, "Valid table at max depth (1) should pass validation")
 }
 
 func TestFlattenTable(t *testing.T) {

--- a/backend/internal/pdf/pdf_test.go
+++ b/backend/internal/pdf/pdf_test.go
@@ -612,7 +612,7 @@ func TestSubRows(t *testing.T) {
 			Intensity:  "ReKom",
 			Sum:        400,
 		},
-		// Row with nested subrows (depth 2)
+		// Row with nested subrows (depth 1)
 		{
 			Amount:     3,
 			Multiplier: "x",

--- a/backend/internal/pdf/pdf_test.go
+++ b/backend/internal/pdf/pdf_test.go
@@ -612,7 +612,7 @@ func TestSubRows(t *testing.T) {
 			Intensity:  "ReKom",
 			Sum:        400,
 		},
-		// Row with nested subrows (depth 1)
+		// Row with nested subrows (depth 2)
 		{
 			Amount:     3,
 			Multiplier: "x",

--- a/frontend/src/components/training/PlanRowCard.vue
+++ b/frontend/src/components/training/PlanRowCard.vue
@@ -97,12 +97,21 @@ function subRowPath(subIndex: number): number[] {
 </script>
 
 <template>
-  <div class="plan-row-card" :class="[`plan-row-card--depth-${depth}`, { 'plan-row-card--parent': hasSubRows }]"
-    :data-testid="depth === 0 ? 'plan-card' : 'plan-card-nested'">
+  <div
+    class="plan-row-card"
+    :class="[`plan-row-card--depth-${depth}`, { 'plan-row-card--parent': hasSubRows }]"
+    :data-testid="depth === 0 ? 'plan-card' : 'plan-card-nested'"
+  >
     <!-- ── Content body ─────────────────────────────────────────────────── -->
-    <textarea v-if="isEditing" :value="row.Content" @blur="handleFieldBlur($event, 'Content')"
-      @keyup.enter.prevent="handleFieldBlur($event, 'Content')" class="plan-row-card__textarea" rows="2"
-      :aria-label="t('display.content')"></textarea>
+    <textarea
+      v-if="isEditing"
+      :value="row.Content"
+      @blur="handleFieldBlur($event, 'Content')"
+      @keyup.enter.prevent="handleFieldBlur($event, 'Content')"
+      class="plan-row-card__textarea"
+      rows="2"
+      :aria-label="t('display.content')"
+    ></textarea>
     <div v-else class="plan-row-card__content-view">
       <ContentWithDrillLinks :content="row.Content" />
     </div>
@@ -114,61 +123,107 @@ function subRowPath(subIndex: number): number[] {
         <!-- Amount -->
         <div class="plan-row-card__metric">
           <span class="plan-row-card__metric-label">{{ t('display.amount') }}</span>
-          <input v-if="isEditing" type="text" inputmode="numeric" pattern="[0-9]*" :value="row.Amount"
-            @blur="handleFieldBlur($event, 'Amount')" @keyup.enter="handleFieldBlur($event, 'Amount')"
-            class="plan-row-card__input plan-row-card__input--small" :aria-label="t('display.amount')" />
+          <input
+            v-if="isEditing"
+            type="text"
+            inputmode="numeric"
+            pattern="[0-9]*"
+            :value="row.Amount"
+            @blur="handleFieldBlur($event, 'Amount')"
+            @keyup.enter="handleFieldBlur($event, 'Amount')"
+            class="plan-row-card__input plan-row-card__input--small"
+            :aria-label="t('display.amount')"
+          />
           <span v-else class="plan-row-card__metric-value">{{ row.Amount }}</span>
         </div>
 
         <!-- Multiplier placeholder to preserve flex layout without visual redundancy -->
         <div class="plan-row-card__metric">
-          <span class="plan-row-card__metric-label plan-row-card__metric--placeholder" aria-hidden="true">{{
-            t('display.multiplier') }}</span>
+          <span
+            class="plan-row-card__metric-label plan-row-card__metric--placeholder"
+            aria-hidden="true"
+            >{{ t('display.multiplier') }}</span
+          >
           <span class="plan-row-card__metric-value">{{ row.Multiplier }}</span>
         </div>
 
         <!-- Distance -->
         <div class="plan-row-card__metric">
           <span class="plan-row-card__metric-label">{{ t('display.distance') }}</span>
-          <input v-if="isEditing && isDistanceEditable" type="text" inputmode="numeric" pattern="[0-9]*"
-            :value="row.Distance" @blur="handleFieldBlur($event, 'Distance')"
-            @keyup.enter="handleFieldBlur($event, 'Distance')" class="plan-row-card__input plan-row-card__input--small"
-            :aria-label="t('display.distance')" />
+          <input
+            v-if="isEditing && isDistanceEditable"
+            type="text"
+            inputmode="numeric"
+            pattern="[0-9]*"
+            :value="row.Distance"
+            @blur="handleFieldBlur($event, 'Distance')"
+            @keyup.enter="handleFieldBlur($event, 'Distance')"
+            class="plan-row-card__input plan-row-card__input--small"
+            :aria-label="t('display.distance')"
+          />
           <span v-else class="plan-row-card__metric-value">{{ row.Distance }}</span>
         </div>
 
         <!-- Break -->
         <div class="plan-row-card__metric">
           <span class="plan-row-card__metric-label">{{ t('display.break') }}</span>
-          <input v-if="isEditing" type="text" :value="row.Break" @blur="handleFieldBlur($event, 'Break')"
-            @keyup.enter="handleFieldBlur($event, 'Break')" class="plan-row-card__input plan-row-card__input--small"
-            :aria-label="t('display.break')" />
+          <input
+            v-if="isEditing"
+            type="text"
+            :value="row.Break"
+            @blur="handleFieldBlur($event, 'Break')"
+            @keyup.enter="handleFieldBlur($event, 'Break')"
+            class="plan-row-card__input plan-row-card__input--small"
+            :aria-label="t('display.break')"
+          />
           <span v-else class="plan-row-card__metric-value">{{ row.Break }}</span>
         </div>
 
         <!-- Intensity -->
         <div class="plan-row-card__metric">
           <span class="plan-row-card__metric-label">{{ t('display.intensity') }}</span>
-          <input v-if="isEditing" type="text" :value="row.Intensity" @blur="handleFieldBlur($event, 'Intensity')"
-            @keyup.enter="handleFieldBlur($event, 'Intensity')" class="plan-row-card__input plan-row-card__input--small"
-            :aria-label="t('display.intensity')" />
+          <input
+            v-if="isEditing"
+            type="text"
+            :value="row.Intensity"
+            @blur="handleFieldBlur($event, 'Intensity')"
+            @keyup.enter="handleFieldBlur($event, 'Intensity')"
+            class="plan-row-card__input plan-row-card__input--small"
+            :aria-label="t('display.intensity')"
+          />
           <span v-else class="plan-row-card__metric-value plan-row-card__metric-value--intensity">{{
             row.Intensity
-            }}</span>
+          }}</span>
         </div>
 
         <!-- Equipment badges — inline with metrics on wide screens, wraps below on narrow -->
-        <div v-if="shouldShowEquipmentMetric" data-testid="equipment-metric"
-          class="plan-row-card__metric plan-row-card__metric--equipment">
+        <div
+          v-if="shouldShowEquipmentMetric"
+          data-testid="equipment-metric"
+          class="plan-row-card__metric plan-row-card__metric--equipment"
+        >
           <span class="plan-row-card__metric-label">{{ t('display.equipment') }}</span>
-          <Multiselect v-if="isEditing" v-model="selectedEquipmentOptions" :options="equipmentOptions" :multiple="true"
-            :close-on-select="false" :clear-on-select="false" :preserve-search="true" :show-labels="false"
-            :placeholder="t('display.equipment')" label="label" track-by="value" class="plan-row-card__multiselect"
-            data-testid="equipment-multiselect" :aria-label="t('display.equipment')" :max-height="160" />
+          <Multiselect
+            v-if="isEditing"
+            v-model="selectedEquipmentOptions"
+            :options="equipmentOptions"
+            :multiple="true"
+            :close-on-select="false"
+            :clear-on-select="false"
+            :preserve-search="true"
+            :show-labels="false"
+            :placeholder="t('display.equipment')"
+            label="label"
+            track-by="value"
+            class="plan-row-card__multiselect"
+            data-testid="equipment-multiselect"
+            :aria-label="t('display.equipment')"
+            :max-height="160"
+          />
           <span v-else class="plan-row-card__equipment-badges">
             <span v-for="eq in row.Equipment" :key="eq" class="plan-row-card__equipment-badge">{{
               getEquipmentLabel(eq)
-              }}</span>
+            }}</span>
           </span>
         </div>
 
@@ -177,33 +232,75 @@ function subRowPath(subIndex: number): number[] {
           <span class="plan-row-card__metric-label">{{ t('display.sum') }}</span>
           <span class="plan-row-card__metric-value plan-row-card__metric-value--sum">{{
             row.Sum
-            }}</span>
+          }}</span>
         </div>
       </div>
 
       <!-- Edit-mode inline action controls (NOT hover-only) -->
-      <div v-if="isEditing" class="plan-row-card__actions" role="toolbar" :aria-label="t('display.row_actions')">
-        <button class="plan-row-card__action-btn plan-row-card__action-btn--move-up" :disabled="isFirst"
-          @click.stop="handleMoveRow('up')" :title="t('display.move_row_up')" :aria-label="t('display.move_row_up')">
+      <div
+        v-if="isEditing"
+        class="plan-row-card__actions"
+        role="toolbar"
+        :aria-label="t('display.row_actions')"
+      >
+        <button
+          class="plan-row-card__action-btn plan-row-card__action-btn--move-up"
+          :disabled="isFirst"
+          @click.stop="handleMoveRow('up')"
+          :title="t('display.move_row_up')"
+          :aria-label="t('display.move_row_up')"
+        >
           <!-- Up arrow pseudo-element via CSS; inner text for a11y -->
-          <span aria-hidden="true" class="plan-row-card__action-icon plan-row-card__action-icon--up"></span>
+          <span
+            aria-hidden="true"
+            class="plan-row-card__action-icon plan-row-card__action-icon--up"
+          ></span>
         </button>
-        <button class="plan-row-card__action-btn plan-row-card__action-btn--move-down" :disabled="isLast"
-          @click.stop="handleMoveRow('down')" :title="t('display.move_row_down')"
-          :aria-label="t('display.move_row_down')">
-          <span aria-hidden="true" class="plan-row-card__action-icon plan-row-card__action-icon--down"></span>
+        <button
+          class="plan-row-card__action-btn plan-row-card__action-btn--move-down"
+          :disabled="isLast"
+          @click.stop="handleMoveRow('down')"
+          :title="t('display.move_row_down')"
+          :aria-label="t('display.move_row_down')"
+        >
+          <span
+            aria-hidden="true"
+            class="plan-row-card__action-icon plan-row-card__action-icon--down"
+          ></span>
         </button>
-        <button class="plan-row-card__action-btn plan-row-card__action-btn--add" @click.stop="handleAddRow"
-          :title="t('display.add_row')" :aria-label="t('display.add_row')">
-          <span aria-hidden="true" class="plan-row-card__action-icon plan-row-card__action-icon--add"></span>
+        <button
+          class="plan-row-card__action-btn plan-row-card__action-btn--add"
+          @click.stop="handleAddRow"
+          :title="t('display.add_row')"
+          :aria-label="t('display.add_row')"
+        >
+          <span
+            aria-hidden="true"
+            class="plan-row-card__action-icon plan-row-card__action-icon--add"
+          ></span>
         </button>
-        <button class="plan-row-card__action-btn plan-row-card__action-btn--remove" @click.stop="handleRemoveRow"
-          :title="t('display.remove_row')" :aria-label="t('display.remove_row')">
-          <span aria-hidden="true" class="plan-row-card__action-icon plan-row-card__action-icon--remove"></span>
+        <button
+          class="plan-row-card__action-btn plan-row-card__action-btn--remove"
+          @click.stop="handleRemoveRow"
+          :title="t('display.remove_row')"
+          :aria-label="t('display.remove_row')"
+        >
+          <span
+            aria-hidden="true"
+            class="plan-row-card__action-icon plan-row-card__action-icon--remove"
+          ></span>
         </button>
-        <button v-if="canAddSubRow" class="plan-row-card__action-btn plan-row-card__action-btn--add-subrow"
-          @click.stop="handleAddSubRow" :title="t('display.add_subrow')" :aria-label="t('display.add_subrow')">
-          <span aria-hidden="true" class="plan-row-card__action-icon plan-row-card__action-icon--subrow"></span>
+        <button
+          v-if="canAddSubRow"
+          class="plan-row-card__action-btn plan-row-card__action-btn--add-subrow"
+          @click.stop="handleAddSubRow"
+          :title="t('display.add_subrow')"
+          :aria-label="t('display.add_subrow')"
+        >
+          <span
+            aria-hidden="true"
+            class="plan-row-card__action-icon plan-row-card__action-icon--subrow"
+          ></span>
         </button>
       </div>
     </div>
@@ -212,9 +309,17 @@ function subRowPath(subIndex: number): number[] {
     <Transition name="subrows-expand">
       <div v-show="hasSubRows" class="plan-row-card__subrows">
         <TransitionGroup name="list">
-          <PlanRowCard v-for="(subRow, subIndex) in row.SubRows" :key="subRow._id || subIndex" :row="subRow"
-            :path="subRowPath(subIndex)" :depth="depth + 1" :is-editing="isEditing" :store="store"
-            :is-first="subIndex === 0" :is-last="subIndex === (row.SubRows?.length ?? 1) - 1" />
+          <PlanRowCard
+            v-for="(subRow, subIndex) in row.SubRows"
+            :key="subRow._id || subIndex"
+            :row="subRow"
+            :path="subRowPath(subIndex)"
+            :depth="depth + 1"
+            :is-editing="isEditing"
+            :store="store"
+            :is-first="subIndex === 0"
+            :is-last="subIndex === (row.SubRows?.length ?? 1) - 1"
+          />
         </TransitionGroup>
       </div>
     </Transition>
@@ -436,7 +541,6 @@ export default {
   padding: 0.75rem;
   font-size: 0.85rem;
 }
-
 
 .plan-row-card__multiselect:deep(.multiselect__option--highlight) {
   background: var(--color-primary);

--- a/frontend/src/components/training/PlanRowCard.vue
+++ b/frontend/src/components/training/PlanRowCard.vue
@@ -346,9 +346,10 @@ export default {
 }
 
 .plan-row-card__multiselect {
-  min-width: 14rem;
+  min-width: 10rem;
   max-width: 18rem;
   font-size: 0.9rem;
+  min-height: unset;
 }
 
 .plan-row-card__input:focus {
@@ -363,12 +364,9 @@ export default {
   color: var(--color-text);
   font-family: inherit;
   font-size: inherit;
+  box-sizing: border-box;
   min-height: 1.8rem;
-  padding: 0.15rem 2rem 0 0.25rem;
-}
-
-.plan-row-card__multiselect:deep(.multiselect__tags-wrap) {
-  display: block;
+  padding: 0.1rem 2rem 0 0.25rem;
 }
 
 .plan-row-card__multiselect:deep(.multiselect__content-wrapper) {
@@ -378,14 +376,15 @@ export default {
 
 .plan-row-card__multiselect:deep(.multiselect__input),
 .plan-row-card__multiselect:deep(.multiselect__single) {
-  background: var(--color-background);
+  background: transparent;
   color: var(--color-text);
   font-size: 0.85rem;
-  margin-bottom: 0;
+  margin: 0 0 0.15rem 0;
   padding: 0;
-  min-height: 1.2rem;
-  line-height: 1.2rem;
+  min-height: 1.5rem;
+  line-height: 1.5rem;
   border: none;
+  display: inherit;
 }
 
 .plan-row-card__multiselect:deep(.multiselect__input::placeholder) {
@@ -397,13 +396,14 @@ export default {
   color: var(--color-heading);
   opacity: 0.6;
   font-size: 0.85rem;
-  margin-bottom: 0;
-  padding-top: 0;
-  line-height: 1.2rem;
+  margin: 0;
+  padding: 0;
+  line-height: 1.5rem;
 }
 
 .plan-row-card__multiselect:deep(.multiselect__select) {
   height: 1.8rem;
+  padding: 0.5rem;
 }
 
 .plan-row-card__multiselect:deep(.multiselect__tag) {
@@ -411,19 +411,16 @@ export default {
   color: white;
   border-radius: 4px;
   font-size: 0.85rem;
-  margin-bottom: 0rem;
-  margin-top: 0.1rem;
-  margin-right: 0.25rem;
-  padding: 0.15rem 1.4rem 0.15rem 0.4rem;
-}
-
-.plan-row-card__multiselect:deep(.multiselect__option) {
-  padding: 0.4rem 0.5rem;
-  min-height: auto;
-  font-size: 0.85rem;
+  margin: 0.2rem 0.15rem 0.2rem 0.1rem;
+  padding: 0 1.4rem 0 0.4rem;
+  line-height: 16px;
+  height: 1.1rem;
+  vertical-align: top;
+  display: inline-block;
 }
 
 .plan-row-card__multiselect:deep(.multiselect__tag-icon) {
+  width: 20px;
   line-height: 16px;
 }
 
@@ -434,6 +431,12 @@ export default {
 .plan-row-card__multiselect:deep(.multiselect__tag-icon:hover) {
   background: var(--color-primary-hover, color-mix(in srgb, var(--color-primary) 80%, black));
 }
+
+.plan-row-card__multiselect:deep(.multiselect__option) {
+  padding: 0.75rem;
+  font-size: 0.85rem;
+}
+
 
 .plan-row-card__multiselect:deep(.multiselect__option--highlight) {
   background: var(--color-primary);

--- a/frontend/src/components/training/PlanRowCard.vue
+++ b/frontend/src/components/training/PlanRowCard.vue
@@ -97,25 +97,14 @@ function subRowPath(subIndex: number): number[] {
 </script>
 
 <template>
-  <div
-    class="plan-row-card"
-    :class="[`plan-row-card--depth-${depth}`, { 'plan-row-card--parent': hasSubRows }]"
-    :data-testid="depth === 0 ? 'plan-card' : 'plan-card-nested'"
-  >
+  <div class="plan-row-card" :class="[`plan-row-card--depth-${depth}`, { 'plan-row-card--parent': hasSubRows }]"
+    :data-testid="depth === 0 ? 'plan-card' : 'plan-card-nested'">
     <!-- ── Content body ─────────────────────────────────────────────────── -->
-    <div>
-      <textarea
-        v-if="isEditing"
-        :value="row.Content"
-        @blur="handleFieldBlur($event, 'Content')"
-        @keyup.enter.prevent="handleFieldBlur($event, 'Content')"
-        class="plan-row-card__textarea"
-        rows="2"
-        :aria-label="t('display.content')"
-      ></textarea>
-      <div v-else class="plan-row-card__content-view">
-        <ContentWithDrillLinks :content="row.Content" />
-      </div>
+    <textarea v-if="isEditing" :value="row.Content" @blur="handleFieldBlur($event, 'Content')"
+      @keyup.enter.prevent="handleFieldBlur($event, 'Content')" class="plan-row-card__textarea" rows="2"
+      :aria-label="t('display.content')"></textarea>
+    <div v-else class="plan-row-card__content-view">
+      <ContentWithDrillLinks :content="row.Content" />
     </div>
 
     <!-- ── Card header: metrics + actions ──────────────────────────────── -->
@@ -125,106 +114,61 @@ function subRowPath(subIndex: number): number[] {
         <!-- Amount -->
         <div class="plan-row-card__metric">
           <span class="plan-row-card__metric-label">{{ t('display.amount') }}</span>
-          <input
-            v-if="isEditing"
-            type="text"
-            inputmode="numeric"
-            pattern="[0-9]*"
-            :value="row.Amount"
-            @blur="handleFieldBlur($event, 'Amount')"
-            @keyup.enter="handleFieldBlur($event, 'Amount')"
-            class="plan-row-card__input plan-row-card__input--small"
-            :aria-label="t('display.amount')"
-          />
+          <input v-if="isEditing" type="text" inputmode="numeric" pattern="[0-9]*" :value="row.Amount"
+            @blur="handleFieldBlur($event, 'Amount')" @keyup.enter="handleFieldBlur($event, 'Amount')"
+            class="plan-row-card__input plan-row-card__input--small" :aria-label="t('display.amount')" />
           <span v-else class="plan-row-card__metric-value">{{ row.Amount }}</span>
         </div>
 
         <!-- Multiplier placeholder to preserve flex layout without visual redundancy -->
         <div class="plan-row-card__metric">
-          <span
-            class="plan-row-card__metric-label plan-row-card__metric--placeholder"
-            aria-hidden="true"
-            >{{ t('display.multiplier') }}</span
-          >
+          <span class="plan-row-card__metric-label plan-row-card__metric--placeholder" aria-hidden="true">{{
+            t('display.multiplier') }}</span>
           <span class="plan-row-card__metric-value">{{ row.Multiplier }}</span>
         </div>
 
         <!-- Distance -->
         <div class="plan-row-card__metric">
           <span class="plan-row-card__metric-label">{{ t('display.distance') }}</span>
-          <input
-            v-if="isEditing && isDistanceEditable"
-            type="text"
-            inputmode="numeric"
-            pattern="[0-9]*"
-            :value="row.Distance"
-            @blur="handleFieldBlur($event, 'Distance')"
-            @keyup.enter="handleFieldBlur($event, 'Distance')"
-            class="plan-row-card__input plan-row-card__input--small"
-            :aria-label="t('display.distance')"
-          />
+          <input v-if="isEditing && isDistanceEditable" type="text" inputmode="numeric" pattern="[0-9]*"
+            :value="row.Distance" @blur="handleFieldBlur($event, 'Distance')"
+            @keyup.enter="handleFieldBlur($event, 'Distance')" class="plan-row-card__input plan-row-card__input--small"
+            :aria-label="t('display.distance')" />
           <span v-else class="plan-row-card__metric-value">{{ row.Distance }}</span>
         </div>
 
         <!-- Break -->
         <div class="plan-row-card__metric">
           <span class="plan-row-card__metric-label">{{ t('display.break') }}</span>
-          <input
-            v-if="isEditing"
-            type="text"
-            :value="row.Break"
-            @blur="handleFieldBlur($event, 'Break')"
-            @keyup.enter="handleFieldBlur($event, 'Break')"
-            class="plan-row-card__input plan-row-card__input--small"
-            :aria-label="t('display.break')"
-          />
+          <input v-if="isEditing" type="text" :value="row.Break" @blur="handleFieldBlur($event, 'Break')"
+            @keyup.enter="handleFieldBlur($event, 'Break')" class="plan-row-card__input plan-row-card__input--small"
+            :aria-label="t('display.break')" />
           <span v-else class="plan-row-card__metric-value">{{ row.Break }}</span>
         </div>
 
         <!-- Intensity -->
         <div class="plan-row-card__metric">
           <span class="plan-row-card__metric-label">{{ t('display.intensity') }}</span>
-          <input
-            v-if="isEditing"
-            type="text"
-            :value="row.Intensity"
-            @blur="handleFieldBlur($event, 'Intensity')"
-            @keyup.enter="handleFieldBlur($event, 'Intensity')"
-            class="plan-row-card__input plan-row-card__input--small"
-            :aria-label="t('display.intensity')"
-          />
+          <input v-if="isEditing" type="text" :value="row.Intensity" @blur="handleFieldBlur($event, 'Intensity')"
+            @keyup.enter="handleFieldBlur($event, 'Intensity')" class="plan-row-card__input plan-row-card__input--small"
+            :aria-label="t('display.intensity')" />
           <span v-else class="plan-row-card__metric-value plan-row-card__metric-value--intensity">{{
             row.Intensity
-          }}</span>
+            }}</span>
         </div>
 
         <!-- Equipment badges — inline with metrics on wide screens, wraps below on narrow -->
-        <div
-          v-if="shouldShowEquipmentMetric"
-          data-testid="equipment-metric"
-          class="plan-row-card__metric plan-row-card__metric--equipment"
-        >
+        <div v-if="shouldShowEquipmentMetric" data-testid="equipment-metric"
+          class="plan-row-card__metric plan-row-card__metric--equipment">
           <span class="plan-row-card__metric-label">{{ t('display.equipment') }}</span>
-          <Multiselect
-            v-if="isEditing"
-            v-model="selectedEquipmentOptions"
-            :options="equipmentOptions"
-            :multiple="true"
-            :close-on-select="false"
-            :clear-on-select="false"
-            :preserve-search="true"
-            :show-labels="false"
-            :placeholder="t('display.equipment')"
-            label="label"
-            track-by="value"
-            class="plan-row-card__multiselect"
-            data-testid="equipment-multiselect"
-            :aria-label="t('display.equipment')"
-          />
+          <Multiselect v-if="isEditing" v-model="selectedEquipmentOptions" :options="equipmentOptions" :multiple="true"
+            :close-on-select="false" :clear-on-select="false" :preserve-search="true" :show-labels="false"
+            :placeholder="t('display.equipment')" label="label" track-by="value" class="plan-row-card__multiselect"
+            data-testid="equipment-multiselect" :aria-label="t('display.equipment')" :max-height="160" />
           <span v-else class="plan-row-card__equipment-badges">
             <span v-for="eq in row.Equipment" :key="eq" class="plan-row-card__equipment-badge">{{
               getEquipmentLabel(eq)
-            }}</span>
+              }}</span>
           </span>
         </div>
 
@@ -233,75 +177,33 @@ function subRowPath(subIndex: number): number[] {
           <span class="plan-row-card__metric-label">{{ t('display.sum') }}</span>
           <span class="plan-row-card__metric-value plan-row-card__metric-value--sum">{{
             row.Sum
-          }}</span>
+            }}</span>
         </div>
       </div>
 
       <!-- Edit-mode inline action controls (NOT hover-only) -->
-      <div
-        v-if="isEditing"
-        class="plan-row-card__actions"
-        role="toolbar"
-        :aria-label="t('display.row_actions')"
-      >
-        <button
-          class="plan-row-card__action-btn plan-row-card__action-btn--move-up"
-          :disabled="isFirst"
-          @click.stop="handleMoveRow('up')"
-          :title="t('display.move_row_up')"
-          :aria-label="t('display.move_row_up')"
-        >
+      <div v-if="isEditing" class="plan-row-card__actions" role="toolbar" :aria-label="t('display.row_actions')">
+        <button class="plan-row-card__action-btn plan-row-card__action-btn--move-up" :disabled="isFirst"
+          @click.stop="handleMoveRow('up')" :title="t('display.move_row_up')" :aria-label="t('display.move_row_up')">
           <!-- Up arrow pseudo-element via CSS; inner text for a11y -->
-          <span
-            aria-hidden="true"
-            class="plan-row-card__action-icon plan-row-card__action-icon--up"
-          ></span>
+          <span aria-hidden="true" class="plan-row-card__action-icon plan-row-card__action-icon--up"></span>
         </button>
-        <button
-          class="plan-row-card__action-btn plan-row-card__action-btn--move-down"
-          :disabled="isLast"
-          @click.stop="handleMoveRow('down')"
-          :title="t('display.move_row_down')"
-          :aria-label="t('display.move_row_down')"
-        >
-          <span
-            aria-hidden="true"
-            class="plan-row-card__action-icon plan-row-card__action-icon--down"
-          ></span>
+        <button class="plan-row-card__action-btn plan-row-card__action-btn--move-down" :disabled="isLast"
+          @click.stop="handleMoveRow('down')" :title="t('display.move_row_down')"
+          :aria-label="t('display.move_row_down')">
+          <span aria-hidden="true" class="plan-row-card__action-icon plan-row-card__action-icon--down"></span>
         </button>
-        <button
-          class="plan-row-card__action-btn plan-row-card__action-btn--add"
-          @click.stop="handleAddRow"
-          :title="t('display.add_row')"
-          :aria-label="t('display.add_row')"
-        >
-          <span
-            aria-hidden="true"
-            class="plan-row-card__action-icon plan-row-card__action-icon--add"
-          ></span>
+        <button class="plan-row-card__action-btn plan-row-card__action-btn--add" @click.stop="handleAddRow"
+          :title="t('display.add_row')" :aria-label="t('display.add_row')">
+          <span aria-hidden="true" class="plan-row-card__action-icon plan-row-card__action-icon--add"></span>
         </button>
-        <button
-          class="plan-row-card__action-btn plan-row-card__action-btn--remove"
-          @click.stop="handleRemoveRow"
-          :title="t('display.remove_row')"
-          :aria-label="t('display.remove_row')"
-        >
-          <span
-            aria-hidden="true"
-            class="plan-row-card__action-icon plan-row-card__action-icon--remove"
-          ></span>
+        <button class="plan-row-card__action-btn plan-row-card__action-btn--remove" @click.stop="handleRemoveRow"
+          :title="t('display.remove_row')" :aria-label="t('display.remove_row')">
+          <span aria-hidden="true" class="plan-row-card__action-icon plan-row-card__action-icon--remove"></span>
         </button>
-        <button
-          v-if="canAddSubRow"
-          class="plan-row-card__action-btn plan-row-card__action-btn--add-subrow"
-          @click.stop="handleAddSubRow"
-          :title="t('display.add_subrow')"
-          :aria-label="t('display.add_subrow')"
-        >
-          <span
-            aria-hidden="true"
-            class="plan-row-card__action-icon plan-row-card__action-icon--subrow"
-          ></span>
+        <button v-if="canAddSubRow" class="plan-row-card__action-btn plan-row-card__action-btn--add-subrow"
+          @click.stop="handleAddSubRow" :title="t('display.add_subrow')" :aria-label="t('display.add_subrow')">
+          <span aria-hidden="true" class="plan-row-card__action-icon plan-row-card__action-icon--subrow"></span>
         </button>
       </div>
     </div>
@@ -310,17 +212,9 @@ function subRowPath(subIndex: number): number[] {
     <Transition name="subrows-expand">
       <div v-show="hasSubRows" class="plan-row-card__subrows">
         <TransitionGroup name="list">
-          <PlanRowCard
-            v-for="(subRow, subIndex) in row.SubRows"
-            :key="subRow._id || subIndex"
-            :row="subRow"
-            :path="subRowPath(subIndex)"
-            :depth="depth + 1"
-            :is-editing="isEditing"
-            :store="store"
-            :is-first="subIndex === 0"
-            :is-last="subIndex === (row.SubRows?.length ?? 1) - 1"
-          />
+          <PlanRowCard v-for="(subRow, subIndex) in row.SubRows" :key="subRow._id || subIndex" :row="subRow"
+            :path="subRowPath(subIndex)" :depth="depth + 1" :is-editing="isEditing" :store="store"
+            :is-first="subIndex === 0" :is-last="subIndex === (row.SubRows?.length ?? 1) - 1" />
         </TransitionGroup>
       </div>
     </Transition>
@@ -353,7 +247,7 @@ export default {
   background: var(--color-background-mute);
 }
 
-/* Depth-specific tinting/indentation — gradient of prominence depth 0→4 */
+/* Depth-specific tinting/indentation — depth 0→1 */
 
 /* Depth 0: top-level, most prominent — strong primary accent */
 .plan-row-card--depth-0 {
@@ -370,31 +264,6 @@ export default {
   font-size: 0.93rem;
 }
 
-/* Depth 2: second-level nesting — muted border, more indent */
-.plan-row-card--depth-2 {
-  border-left: 2px solid var(--color-border-hover);
-  margin-left: 0.5rem;
-  background: var(--color-background-mute);
-  font-size: 0.875rem;
-}
-
-/* Depth 3: very nested — subtle border */
-.plan-row-card--depth-3 {
-  border-left: 2px solid var(--color-border);
-  margin-left: 0.35rem;
-  background: var(--color-background-soft);
-  font-size: 0.82rem;
-}
-
-/* Depth 4: maximum depth — minimal, near-invisible border */
-.plan-row-card--depth-4 {
-  border-left: 1px solid var(--color-border);
-  margin-left: 0.25rem;
-  background: var(--color-background-mute);
-  font-size: 0.78rem;
-  opacity: 0.88;
-}
-
 /* ── Data row ─────────────────────────────────────────────────────────────── */
 
 .plan-row-card__data {
@@ -402,6 +271,7 @@ export default {
   align-items: center;
   gap: 0.75rem;
   flex-wrap: wrap;
+  margin-top: 0.25rem;
 }
 
 /* ── Metrics ────────────────────────────────────────────────────────────────── */
@@ -467,7 +337,7 @@ export default {
   font-family: inherit;
   font-size: inherit;
   box-sizing: border-box;
-  padding: 0.15rem 0.25rem;
+  padding: 0.25rem 0.25rem;
 }
 
 .plan-row-card__input--small {
@@ -477,7 +347,6 @@ export default {
 
 .plan-row-card__multiselect {
   min-width: 14rem;
-  width: 100%;
   max-width: 18rem;
   font-size: 0.9rem;
 }
@@ -494,8 +363,12 @@ export default {
   color: var(--color-text);
   font-family: inherit;
   font-size: inherit;
-  box-sizing: border-box;
-  min-height: 2.25rem;
+  min-height: 1.8rem;
+  padding: 0.15rem 2rem 0 0.25rem;
+}
+
+.plan-row-card__multiselect:deep(.multiselect__tags-wrap) {
+  display: block;
 }
 
 .plan-row-card__multiselect:deep(.multiselect__content-wrapper) {
@@ -507,14 +380,30 @@ export default {
 .plan-row-card__multiselect:deep(.multiselect__single) {
   background: var(--color-background);
   color: var(--color-text);
-  font-size: 0.9rem;
+  font-size: 0.85rem;
   margin-bottom: 0;
+  padding: 0;
+  min-height: 1.2rem;
+  line-height: 1.2rem;
+  border: none;
+}
+
+.plan-row-card__multiselect:deep(.multiselect__input::placeholder) {
+  color: var(--color-heading);
+  opacity: 0.6;
 }
 
 .plan-row-card__multiselect:deep(.multiselect__placeholder) {
   color: var(--color-heading);
   opacity: 0.6;
-  font-size: 0.75rem;
+  font-size: 0.85rem;
+  margin-bottom: 0;
+  padding-top: 0;
+  line-height: 1.2rem;
+}
+
+.plan-row-card__multiselect:deep(.multiselect__select) {
+  height: 1.8rem;
 }
 
 .plan-row-card__multiselect:deep(.multiselect__tag) {
@@ -522,7 +411,20 @@ export default {
   color: white;
   border-radius: 4px;
   font-size: 0.85rem;
-  margin-bottom: 0.2rem;
+  margin-bottom: 0rem;
+  margin-top: 0.1rem;
+  margin-right: 0.25rem;
+  padding: 0.15rem 1.4rem 0.15rem 0.4rem;
+}
+
+.plan-row-card__multiselect:deep(.multiselect__option) {
+  padding: 0.4rem 0.5rem;
+  min-height: auto;
+  font-size: 0.85rem;
+}
+
+.plan-row-card__multiselect:deep(.multiselect__tag-icon) {
+  line-height: 16px;
 }
 
 .plan-row-card__multiselect:deep(.multiselect__tag-icon::after) {
@@ -774,6 +676,7 @@ export default {
 }
 
 /* List Transitions for nested cards */
+.list-move,
 .list-enter-active,
 .list-leave-active {
   transition: all 0.4s ease;
@@ -819,24 +722,24 @@ export default {
     margin-left: 0.5rem;
   }
 
-  .plan-row-card--depth-2 {
-    margin-left: 0.35rem;
-  }
-
-  .plan-row-card--depth-3 {
-    margin-left: 0.25rem;
-  }
-
-  .plan-row-card--depth-4 {
-    margin-left: 0.15rem;
-  }
-
   .plan-row-card__metrics {
     gap: 0.4rem;
+    flex: 1 1 100%;
   }
 
   .plan-row-card__metric {
     min-width: 2rem;
+  }
+
+  .plan-row-card__metric--equipment {
+    flex: 1 1 auto;
+    min-width: 8rem;
+    max-width: 14rem;
+  }
+
+  .plan-row-card__metric--sum {
+    margin-left: auto;
+    text-align: right;
   }
 
   .plan-row-card__metric-label {
@@ -853,8 +756,9 @@ export default {
   }
 
   .plan-row-card__multiselect {
-    min-width: 100%;
-    max-width: none;
+    min-width: auto;
+    width: 100%;
+    max-width: 100%;
   }
 
   /* Ensure touch-friendly button targets (min 44px) */
@@ -866,7 +770,10 @@ export default {
   }
 
   .plan-row-card__actions {
-    gap: 0.15rem;
+    gap: 0.25rem;
+    width: 100%;
+    justify-content: flex-end;
+    margin-top: 0.25rem;
   }
 
   .plan-row-card__subrows {
@@ -887,13 +794,6 @@ export default {
     order: 99;
     flex-basis: 100%;
     margin-top: 0.2rem;
-  }
-}
-
-@media (max-width: 480px) {
-  .plan-row-card__data {
-    flex-direction: column;
-    align-items: stretch;
   }
 }
 </style>

--- a/frontend/src/components/training/__tests__/TrainingPlanDisplay.spec.ts
+++ b/frontend/src/components/training/__tests__/TrainingPlanDisplay.spec.ts
@@ -42,8 +42,8 @@ const createSimplePlan = (): RAGResponse => ({
  * Fixture: Nested plan with depth 1 (parent + children).
  * Top-level: [Exercise-A (parent with SubRows), Exercise-B, Total]
  */
-const createNestedDepth2Plan = (): RAGResponse => ({
-  title: 'Nested Plan (Depth 2)',
+const createNestedDepth1Plan = (): RAGResponse => ({
+  title: 'Nested Plan (Depth 1)',
   description: 'Plan with nested rows at depth 1.',
   table: [
     {

--- a/frontend/src/components/training/__tests__/TrainingPlanDisplay.spec.ts
+++ b/frontend/src/components/training/__tests__/TrainingPlanDisplay.spec.ts
@@ -39,12 +39,12 @@ const createSimplePlan = (): RAGResponse => ({
 })
 
 /**
- * Fixture: Nested plan with depth 2 (parent + 2 children).
+ * Fixture: Nested plan with depth 1 (parent + children).
  * Top-level: [Exercise-A (parent with SubRows), Exercise-B, Total]
  */
 const createNestedDepth2Plan = (): RAGResponse => ({
   title: 'Nested Plan (Depth 2)',
-  description: 'Plan with nested rows at depth 2.',
+  description: 'Plan with nested rows at depth 1.',
   table: [
     {
       Amount: 3,
@@ -103,11 +103,11 @@ const createNestedDepth2Plan = (): RAGResponse => ({
 })
 
 /**
- * Fixture: Deep nesting (depth 3: top-level parent with child that has grandchildren).
+ * Fixture: Deep nesting (depth 1: top-level parent with children).
  */
 const createNestedDepth3Plan = (): RAGResponse => ({
   title: 'Deep Nested Plan (Depth 3)',
-  description: 'Plan with nested rows at depth 3.',
+  description: 'Plan with nested rows at depth 1.',
   table: [
     {
       Amount: 1,
@@ -709,7 +709,7 @@ describe('TrainingPlanDisplay.vue', () => {
       expect(planCards[0]?.text()).not.toContain('Total')
     })
 
-    it('renders nested depth-2 plan with parent and sibling cards', async () => {
+    it('renders nested depth-1 plan with parent and sibling cards', async () => {
       const wrapper = mount(TrainingPlanDisplay, {
         global: {
           plugins: [i18n, createTestingPinia({ createSpy: vi.fn })],
@@ -734,7 +734,7 @@ describe('TrainingPlanDisplay.vue', () => {
       expect(totalCard.length).toBe(0)
     })
 
-    it('renders nested depth-3 plan with proper hierarchy', async () => {
+    it('renders nested depth-1 plan with proper hierarchy', async () => {
       const wrapper = mount(TrainingPlanDisplay, {
         global: {
           plugins: [i18n, createTestingPinia({ createSpy: vi.fn })],

--- a/frontend/src/components/training/__tests__/TrainingPlanDisplay.spec.ts
+++ b/frontend/src/components/training/__tests__/TrainingPlanDisplay.spec.ts
@@ -103,11 +103,11 @@ const createNestedDepth1Plan = (): RAGResponse => ({
 })
 
 /**
- * Fixture: Deep nesting (depth 1: top-level parent with children).
+ * Fixture: Deep nesting (depth 2: top-level parent with child that has grandchildren).
  */
-const createNestedDepth3Plan = (): RAGResponse => ({
-  title: 'Deep Nested Plan (Depth 3)',
-  description: 'Plan with nested rows at depth 1.',
+const createNestedDepth2Plan = (): RAGResponse => ({
+  title: 'Deep Nested Plan (Depth 2)',
+  description: 'Plan with nested rows at depth 2.',
   table: [
     {
       Amount: 1,
@@ -171,7 +171,7 @@ const createNestedDepth3Plan = (): RAGResponse => ({
       Content: 'Total',
       Intensity: '',
       Sum: 1000,
-      _id: 'total-depth3',
+      _id: 'total-depth2',
     },
   ],
 })
@@ -457,7 +457,7 @@ describe('TrainingPlanDisplay.vue', () => {
         },
       })
       const store = useTrainingPlanStore()
-      store.currentPlan = JSON.parse(JSON.stringify(createNestedDepth2Plan()))
+      store.currentPlan = JSON.parse(JSON.stringify(createNestedDepth1Plan()))
       await wrapper.vm.$nextTick()
 
       await wrapper.find('button[data-testid="plan-edit-btn"]').trigger('click')
@@ -602,7 +602,7 @@ describe('TrainingPlanDisplay.vue', () => {
         },
       })
       const store = useTrainingPlanStore()
-      store.currentPlan = createNestedDepth2Plan() // has Equipment: ['Flossen'] in child
+      store.currentPlan = createNestedDepth1Plan() // has Equipment: ['Flossen'] in child
       await wrapper.vm.$nextTick()
 
       const equipmentFooter = wrapper.find('[data-testid="plan-footer-equipment"]')
@@ -719,7 +719,7 @@ describe('TrainingPlanDisplay.vue', () => {
         },
       })
       const store = useTrainingPlanStore()
-      store.currentPlan = createNestedDepth2Plan()
+      store.currentPlan = createNestedDepth1Plan()
       await wrapper.vm.$nextTick()
 
       const planCards = wrapper.findAll('[data-testid="plan-card"]')
@@ -734,7 +734,7 @@ describe('TrainingPlanDisplay.vue', () => {
       expect(totalCard.length).toBe(0)
     })
 
-    it('renders nested depth-1 plan with proper hierarchy', async () => {
+    it('renders nested depth-2 plan with proper hierarchy', async () => {
       const wrapper = mount(TrainingPlanDisplay, {
         global: {
           plugins: [i18n, createTestingPinia({ createSpy: vi.fn })],
@@ -744,7 +744,7 @@ describe('TrainingPlanDisplay.vue', () => {
         },
       })
       const store = useTrainingPlanStore()
-      store.currentPlan = createNestedDepth3Plan()
+      store.currentPlan = createNestedDepth2Plan()
       await wrapper.vm.$nextTick()
 
       const planCards = wrapper.findAll('[data-testid="plan-card"]')
@@ -792,7 +792,7 @@ describe('TrainingPlanDisplay.vue', () => {
         },
       })
       const store = useTrainingPlanStore()
-      store.currentPlan = createNestedDepth2Plan()
+      store.currentPlan = createNestedDepth1Plan()
       await wrapper.vm.$nextTick()
 
       const nestedCards = wrapper.findAll('[data-testid="plan-card-nested"]')

--- a/frontend/src/utils/rowHelpers.ts
+++ b/frontend/src/utils/rowHelpers.ts
@@ -1,7 +1,7 @@
 import type { Row } from '@/types'
 
 /** Matches backend validateRowDepth max depth (plan.go). */
-export const MAX_NESTING_DEPTH = 4
+export const MAX_NESTING_DEPTH = 1
 
 /** Matches backend EquipmentType constants (metadata.go). */
 export const EQUIPMENT_TYPES = [


### PR DESCRIPTION
This pull request introduces a significant change to the allowed nesting depth for training plan rows, reducing the maximum from 4 to 1, and updates both backend validation logic and frontend components/styles accordingly. Additionally, it includes various UI and style refinements for the `PlanRowCard` component to improve usability and visual consistency.

**Maximum nesting depth enforcement and related updates:**

* The backend validation for `Table` rows now enforces a maximum subrow nesting depth of 1 instead of 4. Corresponding test cases and comments have been updated to reflect this new limit. (`backend/internal/models/plan.go`, `backend/internal/models/plan_test.go`, `backend/internal/pdf/pdf_test.go`) [[1]](diffhunk://#diff-8df433579bc7db093f686f0a83615b1effdb967c9746c712600ed48cea89bed1L414-R415) [[2]](diffhunk://#diff-56de8cf50501eacd1de44b99e2a9dfe3cd19a38741b4007c78e877f1a5ab30ecL261-L280) [[3]](diffhunk://#diff-56de8cf50501eacd1de44b99e2a9dfe3cd19a38741b4007c78e877f1a5ab30ecL289-R276) [[4]](diffhunk://#diff-24f48378c8db85f8039ff8ddb97df6f21ad19152ea353d9397f0e4f6a9c845e4L615-R615)
* Frontend `PlanRowCard` component and its styles have been updated to remove references to deeper nesting levels (depth 2–4), ensuring consistency with the new backend constraint. (`frontend/src/components/training/PlanRowCard.vue`) [[1]](diffhunk://#diff-5d861339c539e9f2bd2a3df43888fd856b822da0ea84de0005ddfcff3eefbc2bL356-R250) [[2]](diffhunk://#diff-5d861339c539e9f2bd2a3df43888fd856b822da0ea84de0005ddfcff3eefbc2bL373-R274) [[3]](diffhunk://#diff-5d861339c539e9f2bd2a3df43888fd856b822da0ea84de0005ddfcff3eefbc2bL822-R747)

**UI/UX and style improvements in PlanRowCard:**

* Refactored the template to reduce markup verbosity and improve readability, including more concise input and button markup. (`frontend/src/components/training/PlanRowCard.vue`) [[1]](diffhunk://#diff-5d861339c539e9f2bd2a3df43888fd856b822da0ea84de0005ddfcff3eefbc2bL100-L119) [[2]](diffhunk://#diff-5d861339c539e9f2bd2a3df43888fd856b822da0ea84de0005ddfcff3eefbc2bL128-R167) [[3]](diffhunk://#diff-5d861339c539e9f2bd2a3df43888fd856b822da0ea84de0005ddfcff3eefbc2bL241-R206) [[4]](diffhunk://#diff-5d861339c539e9f2bd2a3df43888fd856b822da0ea84de0005ddfcff3eefbc2bL313-R217)
* Improved the appearance and usability of the equipment multiselect, including sizing, padding, and placeholder styling, as well as better tag and option display. (`frontend/src/components/training/PlanRowCard.vue`) [[1]](diffhunk://#diff-5d861339c539e9f2bd2a3df43888fd856b822da0ea84de0005ddfcff3eefbc2bL470-R340) [[2]](diffhunk://#diff-5d861339c539e9f2bd2a3df43888fd856b822da0ea84de0005ddfcff3eefbc2bL479-R352) [[3]](diffhunk://#diff-5d861339c539e9f2bd2a3df43888fd856b822da0ea84de0005ddfcff3eefbc2bL498-R369) [[4]](diffhunk://#diff-5d861339c539e9f2bd2a3df43888fd856b822da0ea84de0005ddfcff3eefbc2bL508-R424) [[5]](diffhunk://#diff-5d861339c539e9f2bd2a3df43888fd856b822da0ea84de0005ddfcff3eefbc2bR435-R440) [[6]](diffhunk://#diff-5d861339c539e9f2bd2a3df43888fd856b822da0ea84de0005ddfcff3eefbc2bL856-R764)
* Enhanced responsive layout and alignment for metrics and actions in the plan row card, especially for mobile screens. (`frontend/src/components/training/PlanRowCard.vue`)

**Other improvements:**

* The `docker-build-and-run` script now explicitly builds for the `linux/arm64/v8` platform and runs the `swim-gen-backend:latest` image, improving build consistency. (`backend/Taskfile.sh`)
* Minor adjustment to transition classes for smoother nested card animations. (`frontend/src/components/training/PlanRowCard.vue`)