### PR TITLE
chore(ci): bump action versions across all workflows

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -15,13 +15,13 @@ runs:
   using: composite
   steps:
     - name: 🔑 Authenticate to Google Cloud
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@v3
       with:
         workload_identity_provider: ${{ inputs.WIF_PROVIDER }}
         service_account: ${{ inputs.WIF_SA }}
 
     - name: 🕹 Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@v2
+      uses: google-github-actions/setup-gcloud@v3
 
     - name: 📥 Import environment variables
       shell: bash

--- a/.github/workflows/backend-build.yaml
+++ b/.github/workflows/backend-build.yaml
@@ -52,7 +52,7 @@ jobs:
     environment: ${{ inputs.env }}
     steps:
       - name: ⬇️ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ inputs.checkout_repo }}
           ref: ${{ inputs.checkout_ref }}

--- a/.github/workflows/backend-validate.yaml
+++ b/.github/workflows/backend-validate.yaml
@@ -44,7 +44,7 @@ jobs:
     environment: ${{ (github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch') && inputs.env || (github.ref_name == 'main' && 'prod' || 'dev') }}
     steps:
       - name: ⬇️ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ inputs.checkout_repo }}
           ref: ${{ inputs.checkout_ref }}
@@ -75,7 +75,7 @@ jobs:
 
       - name: 🔄 Auto-commit formatting
         if: github.event_name == 'pull_request'
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "chore(fmt): apply go fmt"
           file_pattern: backend/**
@@ -90,13 +90,13 @@ jobs:
 
       - name: 🔄 Auto-commit formatting
         if: github.event_name == 'pull_request'
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "chore(docs): update swagger docs"
           file_pattern: backend/**
 
       - name: 🔎 Lint Code
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           install-mode: goinstall
           working-directory: backend

--- a/.github/workflows/bff-build.yaml
+++ b/.github/workflows/bff-build.yaml
@@ -1,4 +1,3 @@
-
 name: 📦 Build BFF and Push to Google Cloud
 
 on:
@@ -31,7 +30,7 @@ on:
 
 permissions:
   id-token: write # This is required for requesting the JWT
-  contents: write  # This is required for actions/checkout
+  contents: write # This is required for actions/checkout
 
 concurrency:
   group: bff-build-${{ github.workflow }}-${{ github.ref }}
@@ -53,7 +52,7 @@ jobs:
     environment: ${{ inputs.env }}
     steps:
       - name: ⬇️ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ inputs.checkout_repo }}
           ref: ${{ inputs.checkout_ref }}

--- a/.github/workflows/bff-validate.yaml
+++ b/.github/workflows/bff-validate.yaml
@@ -44,7 +44,7 @@ jobs:
     environment: ${{ (github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch') && inputs.env || (github.ref_name == 'main' && 'prod' || 'dev') }}
     steps:
       - name: ⬇️ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ inputs.checkout_repo }}
           ref: ${{ inputs.checkout_ref }}
@@ -58,7 +58,7 @@ jobs:
           env-file: bff/.env.development
 
       - name: 🟢 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24.x
 
@@ -73,7 +73,7 @@ jobs:
 
       - name: 🔄 Auto-commit formatting
         if: github.event_name == 'pull_request'
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "chore(fmt): apply prettier formatting"
           file_pattern: bff/**

--- a/.github/workflows/build-and-deploy-dev.yaml
+++ b/.github/workflows/build-and-deploy-dev.yaml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Get deployment data
         id: get-data
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             if (context.eventName === 'workflow_dispatch') {
@@ -75,7 +75,7 @@ jobs:
       supabase: ${{ steps.filter.outputs.supabase }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ needs.get-deployment-data.outputs.head_repo_full_name }}
           ref: ${{ needs.get-deployment-data.outputs.head_sha }}
@@ -164,7 +164,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add reaction to comment
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -175,7 +175,7 @@ jobs:
               content: '+1'
             });
       - name: Add comment with action link
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -194,7 +194,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Comment on PR
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -212,7 +212,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Comment on PR about failure
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/data-validate.yaml
+++ b/.github/workflows/data-validate.yaml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 

--- a/.github/workflows/frontend-build.yaml
+++ b/.github/workflows/frontend-build.yaml
@@ -52,7 +52,7 @@ jobs:
     environment: ${{ inputs.env }}
     steps:
       - name: ⬇️ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ inputs.checkout_repo }}
           ref: ${{ inputs.checkout_ref }}

--- a/.github/workflows/frontend-validate.yaml
+++ b/.github/workflows/frontend-validate.yaml
@@ -44,7 +44,7 @@ jobs:
     environment: ${{ (github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch') && inputs.env || (github.ref_name == 'main' && 'prod' || 'dev') }}
     steps:
       - name: ⬇️ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ inputs.checkout_repo }}
           ref: ${{ inputs.checkout_ref }}
@@ -59,7 +59,7 @@ jobs:
           env-file: frontend/.env.development
 
       - name: 🟢 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24.x
 
@@ -74,7 +74,7 @@ jobs:
 
       - name: 🔄 Auto-commit formatting
         if: github.event_name == 'pull_request'
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "chore(fmt): apply prettier formatting"
           file_pattern: frontend/**

--- a/.github/workflows/merge-main.yaml
+++ b/.github/workflows/merge-main.yaml
@@ -34,7 +34,7 @@ jobs:
       next_version: ${{ steps.semantic.outputs.new_release_version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Required for semantic-release to analyze the full commit history
       - name: Get next version
@@ -95,7 +95,7 @@ jobs:
       - opentofu-services
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Semantic Release

--- a/.github/workflows/opencode-dependency-update.yaml
+++ b/.github/workflows/opencode-dependency-update.yaml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: ⬇️ Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -35,7 +35,7 @@ jobs:
 
       - name: 🔑 Create Application Default Credentials file
         id: auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ vars.WIF_PROVIDER }}
           service_account: ${{ vars.WIF_SA }}
@@ -48,7 +48,7 @@ jobs:
           cache-dependency-path: backend/go.sum
 
       - name: 🟢 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24.x
 

--- a/.github/workflows/supabase-deploy.yaml
+++ b/.github/workflows/supabase-deploy.yaml
@@ -30,7 +30,7 @@ jobs:
         environment: ${{ inputs.env }}
         steps:
             - name: ⬇️ Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                   repository: ${{ inputs.checkout_repo }}
                   ref: ${{ inputs.checkout_ref }}
@@ -43,7 +43,7 @@ jobs:
                   WIF_SA: ${{ vars.WIF_SA }}
 
             - name: 🧪 Install Supabase CLI
-              uses: supabase/setup-cli@v1
+              uses: supabase/setup-cli@v2
               with:
                   version: latest
 

--- a/.github/workflows/tf-plan-apply.yaml
+++ b/.github/workflows/tf-plan-apply.yaml
@@ -77,7 +77,7 @@ jobs:
 
     steps:
       - name: ⬇️ Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ inputs.checkout_repo }}
           ref: ${{ inputs.checkout_ref }}
@@ -91,7 +91,7 @@ jobs:
           WIF_SA: ${{ vars.WIF_SA }}
 
       - name: 🧩 Install OpenTofu
-        uses: opentofu/setup-opentofu@v1
+        uses: opentofu/setup-opentofu@v2
         with:
           tofu_wrapper: false
 


### PR DESCRIPTION
  - actions/checkout: v4 → v6
  - actions/setup-node: v4 → v6
  - actions/github-script: v7/v8 → v9
  - stefanzweifel/git-auto-commit-action: v5 → v7
  - golangci/golangci-lint-action: v8 → v9
  - google-github-actions/auth: v2 → v3
  - google-github-actions/setup-gcloud: v2 → v3
  - supabase/setup-cli: v1 → v2
  - opentofu/setup-opentofu: v1 → v2