### PR TITLE
fix(observability): filter static asset requests from BigQuery teleme…

### DIFF
--- a/deployments/dev/0-infra/telemetry-views.tf
+++ b/deployments/dev/0-infra/telemetry-views.tf
@@ -160,6 +160,11 @@ resource "google_bigquery_table" "v_request_volume" {
           log_id = "run.googleapis.com/requests"
           AND http_request.status IS NOT NULL
           AND timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1825 DAY)
+          -- Exclude static asset requests (frontend noise: /_next/, /assets/, /public/, *.html, *.svg)
+          AND NOT REGEXP_CONTAINS(
+            http_request.request_url,
+            r'(/_next/|/assets/|/public/|/wordpress/|\.(html|svg|xml|php)(\?|$))'
+          )
       )
 
       -- Per-route breakdown
@@ -224,6 +229,11 @@ resource "google_bigquery_table" "v_request_latency" {
           log_id = "run.googleapis.com/requests"
           AND http_request.latency IS NOT NULL
           AND timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1825 DAY)
+          -- Exclude static asset requests (frontend noise: /_next/, /assets/, /public/, *.html, *.svg)
+          AND NOT REGEXP_CONTAINS(
+            http_request.request_url,
+            r'(/_next/|/assets/|/public/|/wordpress/|\.(html|svg|xml|php)(\?|$))'
+          )
       )
 
       -- Per-route latency
@@ -296,6 +306,11 @@ resource "google_bigquery_table" "v_error_rate" {
           log_id = "run.googleapis.com/requests"
           AND http_request.status IS NOT NULL
           AND timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1825 DAY)
+          -- Exclude static asset requests (frontend noise: /_next/, /assets/, /public/, /wordpress/, *.html, *.svg, *.xml, *.php)
+          AND NOT REGEXP_CONTAINS(
+            http_request.request_url,
+            r'(/_next/|/assets/|/public/|/wordpress/|\.(html|svg|xml|php)(\?|$))'
+          )
       )
 
       -- Per-route error rate

--- a/deployments/dev/0-infra/telemetry-views.tf
+++ b/deployments/dev/0-infra/telemetry-views.tf
@@ -160,7 +160,7 @@ resource "google_bigquery_table" "v_request_volume" {
           log_id = "run.googleapis.com/requests"
           AND http_request.status IS NOT NULL
           AND timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1825 DAY)
-          -- Exclude static asset requests (frontend noise: /_next/, /assets/, /public/, *.html, *.svg)
+          -- Exclude static asset requests (frontend noise: /_next/, /assets/, /public/, /wordpress/, *.html, *.svg, *.xml, *.php)
           AND NOT REGEXP_CONTAINS(
             http_request.request_url,
             r'(/_next/|/assets/|/public/|/wordpress/|\.(html|svg|xml|php)(\?|$))'
@@ -229,7 +229,7 @@ resource "google_bigquery_table" "v_request_latency" {
           log_id = "run.googleapis.com/requests"
           AND http_request.latency IS NOT NULL
           AND timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1825 DAY)
-          -- Exclude static asset requests (frontend noise: /_next/, /assets/, /public/, *.html, *.svg)
+          -- Exclude static asset requests (frontend noise: /_next/, /assets/, /public/, /wordpress/, *.html, *.svg, *.xml, *.php)
           AND NOT REGEXP_CONTAINS(
             http_request.request_url,
             r'(/_next/|/assets/|/public/|/wordpress/|\.(html|svg|xml|php)(\?|$))'

--- a/deployments/prod/0-infra/telemetry-views.tf
+++ b/deployments/prod/0-infra/telemetry-views.tf
@@ -164,6 +164,11 @@ resource "google_bigquery_table" "v_request_volume" {
           log_id = "run.googleapis.com/requests"
           AND http_request.status IS NOT NULL
           AND timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1825 DAY)
+          -- Exclude static asset requests (frontend noise: /_next/, /assets/, /public/, /wordpress/, *.html, *.svg, *.xml, *.php)
+          AND NOT REGEXP_CONTAINS(
+            http_request.request_url,
+            r'(/_next/|/assets/|/public/|/wordpress/|\.(html|svg|xml|php)(\?|$))'
+          )
       )
 
       -- Per-route breakdown
@@ -228,6 +233,11 @@ resource "google_bigquery_table" "v_request_latency" {
           log_id = "run.googleapis.com/requests"
           AND http_request.latency IS NOT NULL
           AND timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1825 DAY)
+          -- Exclude static asset requests (frontend noise: /_next/, /assets/, /public/, /wordpress/, *.html, *.svg, *.xml, *.php)
+          AND NOT REGEXP_CONTAINS(
+            http_request.request_url,
+            r'(/_next/|/assets/|/public/|/wordpress/|\.(html|svg|xml|php)(\?|$))'
+          )
       )
 
       -- Per-route latency
@@ -300,6 +310,11 @@ resource "google_bigquery_table" "v_error_rate" {
           log_id = "run.googleapis.com/requests"
           AND http_request.status IS NOT NULL
           AND timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1825 DAY)
+          -- Exclude static asset requests (frontend noise: /_next/, /assets/, /public/, /wordpress/, *.html, *.svg, *.xml, *.php)
+          AND NOT REGEXP_CONTAINS(
+            http_request.request_url,
+            r'(/_next/|/assets/|/public/|/wordpress/|\.(html|svg|xml|php)(\?|$))'
+          )
       )
 
       -- Per-route error rate


### PR DESCRIPTION
…try views

Exclude noisy frontend requests (/_next/, /assets/, /public/, /wordpress/, *.html, *.svg, *.xml, *.php) from request volume, latency, and error rate BigQuery views in both dev and prod.