### PR TITLE
fix(frontend): add /drill/ location block to ensure SPA fallback with…

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -24,6 +24,12 @@ server {
   add_header X-Content-Type-Options "nosniff" always;
   add_header Cross-Origin-Opener-Policy "same-origin" always;
 
+  # Ensure /drill/ routes with extensions (like .png) bypass the static files regex
+  # and properly fall back to the SPA.
+  location ^~ /drill/ {
+    try_files $uri $uri/ /index.html;
+  }
+
   # Serve static files
   location / {
     try_files $uri $uri/ /index.html;


### PR DESCRIPTION
… extensions

Add nginx location block for /drill/ routes to bypass static files regex matching so that URLs like /drill/something.png properly fall back to index.html for SPA rendering.