### PR TITLE
feat: use Gemini 3.6 Flash models

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,8 +3,8 @@ PROJECT_ID=your-gcp-project-id
 REGION=eu
 
 # Generative AI models
-MODEL=gemini-3.5-flash
-SMALL_MODEL=gemini-3.5-flash-lite
+MODEL=gemini-3.6-flash
+SMALL_MODEL=gemini-3.6-flash-lite
 
 # Embedding stores
 EMBEDDING_NAME=embeddings

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -13,7 +13,7 @@ type Config struct {
 	ProjectID  string `env:"PROJECT_ID"`
 	Region     string `env:"REGION"`
 	Model      string `env:"MODEL"`
-	SmallModel string `env:"SMALL_MODEL" default:"gemini-3.5-flash-lite"`
+	SmallModel string `env:"SMALL_MODEL" default:"gemini-3.6-flash-lite"`
 	LogLevel   string `env:"LOG_LEVEL"`
 	Port       string `env:"PORT"`
 

--- a/deployments/dev/1-services/terraform.tfvars
+++ b/deployments/dev/1-services/terraform.tfvars
@@ -1,5 +1,5 @@
-model                = "gemini-3.5-flash"
-small_model          = "gemini-3.5-flash-lite"
+model                = "gemini-3.6-flash"
+small_model          = "gemini-3.6-flash-lite"
 embedding_name       = "embeddings"
 embedding_drill_name = "drill_embeddings"
 embedding_model      = "gemini-embedding-2"

--- a/deployments/dev/1-services/variables.tf
+++ b/deployments/dev/1-services/variables.tf
@@ -24,13 +24,13 @@ variable "supabase_access_token" {
 variable "model" {
   description = "The model name"
   type        = string
-  default     = "gemini-3.5-flash"
+  default     = "gemini-3.6-flash"
 }
 
 variable "small_model" {
   description = "The small model name"
   type        = string
-  default     = "gemini-3.5-flash-lite"
+  default     = "gemini-3.6-flash-lite"
 }
 
 variable "genai_region" {

--- a/deployments/prod/1-services/terraform.tfvars
+++ b/deployments/prod/1-services/terraform.tfvars
@@ -1,5 +1,5 @@
-model                = "gemini-3.5-flash"
-small_model          = "gemini-3.5-flash-lite"
+model                = "gemini-3.6-flash"
+small_model          = "gemini-3.6-flash-lite"
 embedding_name       = "embeddings"
 embedding_drill_name = "drill_embeddings"
 embedding_model      = "gemini-embedding-2"

--- a/deployments/prod/1-services/variables.tf
+++ b/deployments/prod/1-services/variables.tf
@@ -24,13 +24,13 @@ variable "supabase_access_token" {
 variable "model" {
   description = "The model name"
   type        = string
-  default     = "gemini-3.5-flash"
+  default     = "gemini-3.6-flash"
 }
 
 variable "small_model" {
   description = "The small model name"
   type        = string
-  default     = "gemini-3.5-flash-lite"
+  default     = "gemini-3.6-flash-lite"
 }
 
 variable "genai_region" {


### PR DESCRIPTION
## Summary
- replace Gemini 3.5 Flash with Gemini 3.6 Flash
- update standard and lite model configuration for dev and prod

## Verification
- `git diff --check`
- confirmed no remaining `gemini-3.5-flash` references